### PR TITLE
Get calendar day endpoint

### DIFF
--- a/app/controllers/api/v1/calendar_controller.rb
+++ b/app/controllers/api/v1/calendar_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::CalendarController < ApplicationController
+  def show
+    calendar_day = CalendarDay.new(params[:user_id], params[:date])
+
+    render json: CalendarDaySerializer.new(calendar_day)
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,12 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.by_date_and_user(date, user_id, collection=false)
+    if collection == false
+      self.where(created_at: date).where(user_id: user_id).first
+    else
+      self.where(created_at: date).where(user_id: user_id)
+    end
+  end
+
 end

--- a/app/models/calendar_day.rb
+++ b/app/models/calendar_day.rb
@@ -1,0 +1,51 @@
+class CalendarDay
+  attr_reader :id,
+              :user_id,
+              :date
+
+  def initialize(user_id, date)
+    @id = Time.now
+    @user_id = user_id.to_i
+    @date = date
+    @_journal_object = nil
+    @_tone_object = nil
+    @_affirmation_objects = nil
+  end
+
+  def lookup_date
+    Date.parse(date)
+  end
+
+  def journal_object
+    @_journal_object ||= JournalEntry.by_date_and_user(lookup_date, user_id)
+  end
+
+  def tone_object
+    journal_id = journal_object.id
+    @_tone_object ||= ToneResponse.by_journal_entry(journal_id)
+  end
+
+  def affirmation_objects
+    @_affirmation_objects ||= Affirmation.by_date_and_user(lookup_date, user_id, true)
+  end
+
+  def journal_entry_text
+    journal_object.entry_text
+  end
+
+  def primary_tone
+    tone_object.primary_tone
+  end
+
+  def primary_score
+    tone_object.primary_score
+  end
+
+  def affirmations
+    affirmation_objects.map do |affirmation|
+      text = affirmation[:affirmation_text]
+      result = {affirmation_text: text}
+    end
+  end
+
+end

--- a/app/models/tone_response.rb
+++ b/app/models/tone_response.rb
@@ -1,4 +1,9 @@
 class ToneResponse < ApplicationRecord
   validates_presence_of :primary_tone, :primary_score
   belongs_to :journal_entry
+
+  def self.by_journal_entry(journal_entry_id)
+    self.find_by(journal_entry_id: journal_entry_id)
+  end
+
 end

--- a/app/serializers/calendar_day_serializer.rb
+++ b/app/serializers/calendar_day_serializer.rb
@@ -1,0 +1,21 @@
+class CalendarDaySerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :date
+
+  attribute :journal_entry_text do |obj|
+    obj.journal_entry_text
+  end
+
+  attribute :primary_tone do |obj|
+    obj.primary_tone
+  end
+
+  attribute :primary_score do |obj|
+    obj.primary_score
+  end
+
+  attribute :affirmations do |obj|
+    obj.affirmations
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       resources :users, only: [:show] do
         get '/journal_entries', to: "journal_entries#show"
         patch '/journal_entries', to: "journal_entries#update"
+        get '/calendar', to: "calendar#show"
         resources :journal_entries, only: [:new, :create, :index]
         resources :affirmations, only: [:new, :create, :show, :index]
       end

--- a/spec/factories/affirmations.rb
+++ b/spec/factories/affirmations.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :affirmation do
     user { nil }
-    sequence :affirmation_text   { |n| "I am beautiful! #{n}" }
+    sequence :affirmation_text   { |n| "This is an affirmation example #{n}" }
   end
 end

--- a/spec/factories/tone_respones.rb
+++ b/spec/factories/tone_respones.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :tone_response do
     journal_entry { nil }
-    primary_tone   { nil }
+    primary_tone   { ["anger", "joy", "sadness", "tentative", "analytical", "confident", "fear"].sample  }
     primary_score   { 0.88 }
   end
 end

--- a/spec/fixtures/tone_analyzer_results.json
+++ b/spec/fixtures/tone_analyzer_results.json
@@ -1,0 +1,11 @@
+{
+    "document_tone": {
+        "tones": [
+            {
+                "score": 0.849638,
+                "tone_id": "joy",
+                "tone_name": "Joy"
+            }
+        ]
+    }
+}

--- a/spec/requests/api/v1/calendar_day/user_past_calendar_day_spec.rb
+++ b/spec/requests/api/v1/calendar_day/user_past_calendar_day_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+require "date"
+
+describe "GET /api/v1/users/:id/calendar?date=YYYY-MM-DD" do
+  it "returns the journal entry, tone response, and affirmations created and saved on the queried date" do
+    date = Date.new(2019,01,17)
+
+    user = create(:user)
+    journal_entry = create(:journal_entry, created_at: date, user: user, entry_text: "Today was really challenging. I hope things are easier tomorrow.")
+    tone_response = create(:tone_response, primary_tone: "sadness", journal_entry: journal_entry)
+    create_list(:affirmation, 3, user: user, created_at: date)
+
+    get "/api/v1/users/#{user.id}/calendar?date=2019-01-17"
+
+    calendar_day = JSON.parse(response.body, symbolize_names: true)
+
+    expect(calendar_day).to have_key(:data)
+    expect(calendar_day[:data]).to have_key(:id)
+    expect(calendar_day[:data]).to have_key(:type)
+    expect(calendar_day[:data]).to have_key(:attributes)
+    expect(calendar_day[:data][:attributes]).to have_key(:date)
+
+    expect(calendar_day[:data][:attributes]).to have_key(:journal_entry_text)
+    expect(calendar_day[:data][:attributes][:journal_entry_text]).to eq journal_entry.entry_text
+
+    expect(calendar_day[:data][:attributes]).to have_key(:primary_tone)
+    expect(calendar_day[:data][:attributes][:primary_tone]).to eq tone_response.primary_tone
+
+    expect(calendar_day[:data][:attributes]).to have_key(:primary_score)
+    expect(calendar_day[:data][:attributes][:primary_score]).to eq tone_response.primary_score.to_s
+
+    expect(calendar_day[:data][:attributes]).to have_key(:affirmations)
+    expect(calendar_day[:data][:attributes][:affirmations]).to be_an Array
+    expect(calendar_day[:data][:attributes][:affirmations].first).to have_key(:affirmation_text)
+    expect(calendar_day[:data][:attributes][:affirmations].length).to eq 3
+  end
+end

--- a/spec/requests/api/v1/user_journals/update_current_day_journal_spec.rb
+++ b/spec/requests/api/v1/user_journals/update_current_day_journal_spec.rb
@@ -2,7 +2,14 @@ require "rails_helper"
 require "date"
 
 describe "PATCH /api/v1/users/:id/journals?date=today" do
-  xit "Updates existing journal entry for the current date with the submitted text" do
+
+  before(:each) do
+    stub_request(:post, /gateway.watsonplatform.net/).
+      to_return(body: File.read("./spec/fixtures/tone_analyzer_results.json"))
+  end
+
+  it "Updates existing journal entry for the current date with the submitted text" do
+
     user = create(:user)
     journal_entry = create(:journal_entry, created_at: Date.today, user: user, entry_text: "I had such a bad day today.")
     tone_response = create(:tone_response, primary_tone: "Sadness", journal_entry: journal_entry)
@@ -29,7 +36,7 @@ describe "PATCH /api/v1/users/:id/journals?date=today" do
     expect(journal_response[:data][:attributes][:tones][:primary_tone]).to eq "joy"
   end
 
-  xit "Updates blank journal entry for the current date with the submitted text" do
+  it "Updates blank journal entry for the current date with the submitted text" do
     user = create(:user)
     journal_entry = create(:journal_entry, created_at: Date.today, user: user, entry_text: nil)
 


### PR DESCRIPTION
- [x] Wrote Tests
- [x] Implemented
- [x] Reviewed

# Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [x] New feature
- [x] Bug Fix

# Implements/Fixes:
* description

This branch:
- adds stubs to the update_journal_entry request as not to call the API during testing
- creates a route and controller for the calendar
- creates a PORO and serializer for the calendar_day (containing journal text, primary tone and score, and affirmations) to be sent in the API response
- adds ApplicationRecord method and Tone Response class method to pull DB objects by user_id, date, and journal_id, as applicable.

* closes #25 

# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed

# Please include a link to a gif of how you feel about this branch:
![](https://media.giphy.com/media/cdNSp4L5vCU7aQrYnV/giphy.gif)