### PR TITLE
Update serializer to return day of month only in the ID

### DIFF
--- a/app/serializers/tone_response_serializer.rb
+++ b/app/serializers/tone_response_serializer.rb
@@ -2,6 +2,6 @@ class ToneResponseSerializer
   include FastJsonapi::ObjectSerializer
   attributes :primary_tone
   set_id do |object|
-    object.created_at.strftime('%Y-%m-%d')
+    object.created_at.strftime('%d')
   end
 end


### PR DESCRIPTION
- [] Wrote Tests
- [x] Implemented
- [x] Reviewed

# Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [x] New feature
- [] Bug Fix

# Implements/Fixes:
* description

Changes serializer return attribute for ID from full date string to just a string of the day of the month

# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed
