### PR TITLE
User refresh token cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'rack-cors', require: 'rack/cors'
 gem 'crono'
 gem 'haml'
 gem 'sinatra', require: nil
+gem 'actionpack-action_caching'
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionpack-action_caching (1.2.0)
+      actionpack (>= 4.0.0, < 6)
     actionview (5.2.2)
       activesupport (= 5.2.2)
       builder (~> 3.1)
@@ -216,6 +218,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-action_caching
   awesome_print
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)

--- a/app/controllers/api/v1/journal_entries_controller.rb
+++ b/app/controllers/api/v1/journal_entries_controller.rb
@@ -2,7 +2,8 @@ class Api::V1::JournalEntriesController < ApplicationController
 
   def show
     if params[:date] == "today"
-      journal = JournalEntry.where(created_at: Date.today).first_or_create(user_id: params[:user_id])
+      user = User.find(params[:user_id])
+      journal = JournalEntry.where(created_at: Date.today).where(user: user).first_or_create(user: user)
 
       render json: JournalEntrySerializer.new(journal)
     else
@@ -12,6 +13,7 @@ class Api::V1::JournalEntriesController < ApplicationController
   def update
     if params[:date] == "today"
       journal = JournalEntry.find_user_daily_journal(params[:user_id])
+
       journal.update(journal_params)
       journal.save
       journal.get_tone_results

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,6 @@
 class ApplicationController < ActionController::API
+
+  def current_user
+    @current_user ||= User.find(params[:user_id])
+  end
 end

--- a/app/models/journal_entry.rb
+++ b/app/models/journal_entry.rb
@@ -33,11 +33,11 @@ class JournalEntry < ApplicationRecord
 
   private
     def ibm_authorization_service
-      @service ||= IbmApiAuthService.new
+      @service ||= IbmApiAuthService.new(self.user_id)
     end
 
     def tone_analyzer_service
-      token = ibm_authorization_service.access_token
+      token = ibm_authorization_service.refresh_access_token
       WatsonToneService.new(self.entry_text, token)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   validates_presence_of :email, :name
+  # validates_presence_of :refresh_token
   has_many :affirmations
   has_many :journal_entries
   has_many :tone_responses, through: :journal_entries
@@ -7,4 +8,15 @@ class User < ApplicationRecord
   validates :email, uniqueness: true
 
   has_secure_password validations: false
+
+  after_create do
+    refresh_token = ibm_authorization_service.access_information[:refresh_token]
+    self.update(refresh_token: refresh_token)
+  end
+
+  private
+    def ibm_authorization_service
+      @service ||= IbmApiAuthService.new
+    end
+
 end

--- a/app/services/ibm_api_auth_service.rb
+++ b/app/services/ibm_api_auth_service.rb
@@ -1,6 +1,26 @@
 class IbmApiAuthService
-  def initialize
+  def initialize(user_id=nil)
     @apikey = ENV['WATSON_DEV_API_KEY']
+    @user_id = user_id
+    @_refresh_token = nil
+    @access_token = nil
+  end
+
+  def refresh_token #cache this value?
+    @_refresh_token ||= User.find(@user_id).refresh_token
+  end
+
+  def refresh_access_token #cache this value after 1 hour - methid is called every time update is hit
+
+    Rails.cache.fetch("#{@user_id}/authorization_token", expires_in: 1.hours) do
+      result = get_json(
+        conn.post do |req|
+          req.url "identity/token"
+          req.body = URI.encode_www_form({ grant_type: 'refresh_token', refresh_token: refresh_token})
+        end.body)
+      @access_token = result[:access_token]
+    end
+    
   end
 
   def access_information
@@ -9,10 +29,6 @@ class IbmApiAuthService
         req.url "identity/token"
         req.body = URI.encode_www_form({ grant_type: 'urn:ibm:params:oauth:grant-type:apikey', apikey: @apikey})
       end.body)
-  end
-
-  def access_token
-    access_information[:access_token]
   end
 
 private

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,6 +6,8 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
+  config.action_controller.perform_caching = true
+
   # Do not eager load code on boot.
   config.eager_load = false
 

--- a/db/migrate/20190220034510_add_auth_token_to_users.rb
+++ b/db/migrate/20190220034510_add_auth_token_to_users.rb
@@ -1,0 +1,9 @@
+class AddAuthTokenToUsers < ActiveRecord::Migration[5.2]
+  def up
+    add_column :users, :refresh_token, :string
+  end
+
+  def down
+    remove_column :users, :refresh_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_13_203129) do
+ActiveRecord::Schema.define(version: 2019_02_20_034510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2019_02_13_203129) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "refresh_token"
   end
 
   add_foreign_key "affirmations", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@ require 'date'
 
 current_date = Date.today
 
-user_1 = User.create(name: "Kelly Smith", password: "password", email: "kelly_smith@email.com")
+user_1 = User.create(name: "Kelly Smith", password: "password", email: "kelly_smith@email.com", refresh_token: "ReWxYFNYJdA-O7_fn65R0Irx47VE39aZTQtkVbL8NWrj9rricJvq6kcOm2jCx5hQVDAorovhTaE2CkPAQviCs5z_1W_l-zR1y-JIiqmlKaflKt1wZIyBbzyrRJ_-RBCDcu1RLDHticJ-6E7jkvxTnYha7p1roPH9XxIDinqfDmnR-fSkc6XPCKkRn5R_To-yTGQXH5FRaFbVRd-T5R8doYB3Ck4nownlDUaII2e7JwPwNcOLbDrb-E_uhScnWt7wISI4-P9bu3kpzQQBoH9HTx8y4AQ6h2A_R0_cMZW94bmWBze8q0AquwdjuMHNi2nwoAq3GE3hGzWP9OIvhyDscNpdVaakVMpCc1BrzPktznYTrZO5EgQIHISipTxkqZ-8PqQX7ldnmw0iA-A4MwiV0tHH1iNCN3GtmINVkx2g6U5xspWVcrihyuIEJMF4QqgXCkCr7vWMuwKIMIX1S2D_lw4h6wz61TmR86beF9_13Xs9INzbhL7IYTkR49_XuwXAovQozqVfdrYBELXQf2ZVoexpe4IgLCVVcguU-8cIYtokXiS9kFn8tki6atTxBb8zFkGO3HVio-LSE9bx2FLald_it4_muWBFkSk24xZ8c8yGq978gHRTJRt6P5JIjKJIEgWbXzbne5NV7vwpXFisSQMEUpsa0MXTuAbPRhmxnMV6zfDHDKYbzNBLoMgKyPDRIxN5GHwbGWfmbfVIQeat19WtvoT8y1BlQYCj7aHkwTJKwZvN2CKCGwd3d_AM_fSEd1u0AzUPzY2WKiFfIRB2smREg-ETrBRixmh39tenqiS9FzxcTD7WITKQM8OeZkRuR3e-nLOfaA_CpgtFsysGRDvcApDhMLW9Q2pc8OqtcnTwM9QFzaK2RENQ_WvjsIR_dv1odUA7wM-WyjTFBa36u350qmpZwDxpSKLaFISkx19yJToaqmuJfNFT2kHJ-JEn-P5ldI9peMr7MvfTUISZO-sP")
 
 Affirmation.create(created_at: current_date - 7.days, affirmation_text: "I am beautiful.", user: user_1)
 Affirmation.create(created_at: current_date - 1.days, affirmation_text: "I am kind.", user: user_1)

--- a/spec/services/ibm_api_auth_service_spec.rb
+++ b/spec/services/ibm_api_auth_service_spec.rb
@@ -13,12 +13,5 @@ describe IbmApiAuthService do
       expect(results).to have_key(:access_token)
     end
   end
-  it "returns API authorization key" do
-    VCR.use_cassette("ibm_api_authorization") do
-      service = IbmApiAuthService.new
-      results = service.access_token
-      
-      expect(results).to be_a(String)
-    end
-  end
+
 end

--- a/spec/services/watson_tone_service_spec.rb
+++ b/spec/services/watson_tone_service_spec.rb
@@ -6,8 +6,8 @@ describe WatsonToneService do
   end
   it "returns a tone" do
       ibm_auth = IbmApiAuthService.new
-      token = ibm_auth.access_token
-    VCR.use_cassette("watson_tone_request") do
+      token = ENV['WATSON_DEV_BEARER_KEY']
+      VCR.use_cassette("watson_tone_request") do
       service = WatsonToneService.new("dogs are awesome", token)
       results = service.get_tone
 


### PR DESCRIPTION
- [] Wrote Tests
- [x] Implemented
- [x] Reviewed

# Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [x] New feature
- [] Bug Fix

# Implements/Fixes:
* description:

This branch creates a column in the User table to store a refresh token, which is generated for a user when the user is created. The Watson Tone API is called using an auth token generated/cached every hour using the user's refresh token.

* closes #48 

# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [] No Tests have been changed
- [x] Some Tests have been changed

# Please include a link to a gif of how you feel about this branch:
![](https://media.giphy.com/media/3ornkdtVzQfIRpwfug/giphy.gif)