### PR TITLE
Update affirmation wrapper and calendar day with updated queries

### DIFF
--- a/app/models/affirmation_wrapper.rb
+++ b/app/models/affirmation_wrapper.rb
@@ -8,7 +8,7 @@ class AffirmationWrapper
   end
 
   def affirmation_objects
-    @_affirmation_objects ||= Affirmation.within_period_by_user(@user_id,@date)
+    @_affirmation_objects ||= Affirmation.within_period_by_user(user_id,date)
   end
 
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -10,8 +10,8 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def self.within_period_by_user(user_id, date)
-    formatted_date = Date.strptime(date, '%Y-%m')
-    self.where(user_id: user_id).where(created_at: formatted_date.beginning_of_month..formatted_date.end_of_month)
+    queried_month = Date.strptime(date, '%Y-%m')
+    x = self.where(created_at: queried_month.beginning_of_month..queried_month.end_of_month).where(user_id: user_id)
   end
 
 end

--- a/app/models/calendar_day.rb
+++ b/app/models/calendar_day.rb
@@ -17,7 +17,8 @@ class CalendarDay
   end
 
   def journal_object
-    @_journal_object ||= JournalEntry.by_date_and_user(lookup_date, user_id)
+    queried_date = Date.parse(date)
+    @_journal_object ||= JournalEntry.where(created_at: queried_date).where(user_id: user_id).first
   end
 
   def tone_object
@@ -26,7 +27,8 @@ class CalendarDay
   end
 
   def affirmation_objects
-    @_affirmation_objects ||= Affirmation.by_date_and_user(lookup_date, user_id, true)
+    queried_date = Date.parse(date)
+    @_affirmation_objects ||= Affirmation.where(created_at: queried_date.beginning_of_day..queried_date.end_of_day).where(user_id: user_id)
   end
 
   def journal_entry_text

--- a/app/serializers/affirmation_wrapper_serializer.rb
+++ b/app/serializers/affirmation_wrapper_serializer.rb
@@ -9,7 +9,11 @@ class AffirmationWrapperSerializer
       date = (aff.created_at).strftime('%Y-%m-%d')
       hash[:date] = date
       hash[:affirmation_text] = aff.affirmation_text
-      hash[:tone] = user.tone_responses.where(created_at: date).first.primary_tone
+      if user.tone_responses.where(created_at: date).first == nil
+        hash[:tone] = "undeterminable"
+      else
+        hash[:tone] = user.tone_responses.where(created_at: date).first.primary_tone
+      end
       hash
     end
   end

--- a/app/serializers/affirmation_wrapper_serializer.rb
+++ b/app/serializers/affirmation_wrapper_serializer.rb
@@ -3,17 +3,13 @@ class AffirmationWrapperSerializer
   attributes :date
   attribute :affirmations do |object|
     user_id = object.affirmation_objects.first.user_id
-    user = User.find(user_id)
     object.affirmation_objects.map do |aff|
       hash = Hash.new
       date = (aff.created_at).strftime('%Y-%m-%d')
       hash[:date] = date
       hash[:affirmation_text] = aff.affirmation_text
-      if user.tone_responses.where(created_at: date).first == nil
-        hash[:tone] = "undeterminable"
-      else
-        hash[:tone] = user.tone_responses.where(created_at: date).first.primary_tone
-      end
+      tone_date = aff.created_at
+      hash[:tone] = ToneResponse.where(created_at: tone_date.beginning_of_day..tone_date.end_of_day).first.primary_tone
       hash
     end
   end


### PR DESCRIPTION
- [] Wrote Tests
- [x] Implemented
- [x] Reviewed

# Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [] New feature
- [x] Bug Fix

# Implements/Fixes:
* description:

This branch edits the affirmation wrapper and calendar day to pull a correct AR query by created_at date timeframe, which was previously not pulling all the instances expected, and causing the errors in logic expecting those instances. Also, this branch take into consideration if a journal entry doesnt have a primary_tone associated with it (undeterminable by the API). In such instances, the tone returned will simply be returned "undeterminable". All endpoints are functioning correctly locally.

* closes #63 

# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed

# Please include a link to a gif of how you feel about this branch:
![](https://media.giphy.com/media/ZebTmyvw85gnm/giphy.gif)